### PR TITLE
ci: only run triage when repository owned by revoltchat organization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 ## Please make sure to check the following tasks before opening and submitting a PR
 
-- [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
+- [ ] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
 - [ ] I have tested my changes locally and they are working as intended

--- a/workflows/triage_issue.yml
+++ b/workflows/triage_issue.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   track_issue:
+    if: github.repository_owner == 'revoltchat'
     runs-on: ubuntu-latest
     steps:
       - name: Get project data

--- a/workflows/triage_pr.yml
+++ b/workflows/triage_pr.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   track_pr:
+    if: github.repository_owner == 'revoltchat'
     runs-on: ubuntu-latest
     steps:
       - name: Get project data


### PR DESCRIPTION
As per discussion in https://github.com/revoltchat/revite/pull/1103 I am filing a PR in this repo for the workflows. There is also a `.github/pull_request_template.md` but it is not synced.

## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended
